### PR TITLE
Don't create database admin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 A Dockerfile that produces a Docker image for [Apache CouchDB](http://couchdb.apache.org/).
 
-It is based on the [Ferran Rodenas's version](https://github.com/frodenas/docker-couchdb) but includes the following changes and improvements:
+It is based on the [Ferran Rodenas's version](https://github.com/frodenas/docker-couchdb)
+but includes the following changes and improvements:
 
   - adds sample CORS configuration to CouchDB,
   - runs everything as user `couchdb`,
-  - uses the most recent version of CouchDB (1.6.1 instead of 1.6),
-  - is based on Debian Wheezy (instead of Ubuntu),
+  - uses CouchDB 1.6.1,
+  - is based on Debian Wheezy,
   - its Docker image is smaller.
 
 ## CouchDB version
@@ -18,13 +19,13 @@ The `master` branch currently hosts CouchDB 1.6.1.
 
 ### Build the image
 
-To create the image `kobretti/couchdb-cors`, execute the following command on the `docker-couchdb` directory:
+To create the image, execute the following command on the `docker-couchdb` directory:
 
 ```
 $ docker build -t kobretti/couchdb-cors .
 ```
 
-### Run the image
+### Create Docker container from image
 
 To run the image and bind to host port 5984:
 
@@ -32,14 +33,17 @@ To run the image and bind to host port 5984:
 $ docker run -d --name couchdb -p 5984:5984 kobretti/couchdb-cors
 ```
 
-The first time you run your container, a new user `couchdb` with all privileges will be created with a random password.
+#### Admin user with random password
+
+If you set the `COUCHDB_USERNAME` environment variable via the `-e` flag to the command above,
+a new user with all privileges will be created.  The password will be randomly generated.
 To get the password, check the logs of the container by running:
 
 ```
 docker logs <CONTAINER_ID>
 ```
 
-You will see an output like the following:
+You should see an output like the following:
 
 ```
 ========================================================
@@ -50,12 +54,8 @@ CouchDB Password: "jPp5fBJySeuJPTN8"
 
 #### Credentials
 
-If you want to preset credentials instead of a random generated ones, you can set the following environment variables:
-
-* `COUCHDB_USERNAME` to set a specific username
-* `COUCHDB_PASSWORD` to set a specific password
-
-On this example we will preset our custom username and password:
+If you want to preset credentials, you can also specify the `COUCHDB_PASSWORD` environment
+variable.  Please note, the `COUCHDB_USERNAME` variable is required in this scenario, e.g.:
 
 ```
 $ docker run -d \
@@ -66,18 +66,22 @@ $ docker run -d \
     kobretti/couchdb-cors
 ```
 
+#### No admin user
+
+If neither `COUCHDB_USERNAME` nor `COUCHDB_PASSWORD` are set when you create a container,
+the administrator account will not be created.
+
 #### Databases
 
-If you want to create a database at container's boot time, you can set the following environment variables:
+If you want to create a database at container's boot time, you can set the `COUCHDB_DBNAME`
+environment variable.  The database is going to be created even if the credentials have not been set.
 
-* `COUCHDB_DBNAME` to create a database
-
-On this example we will preset our custom username and password and we will create a database:
+In this example we will preset our custom username and password and we will create a database:
 
 ```
 $ docker run -d \
     --name couchdb \
-    -p 5984:5984 \
+    -P \
     -e COUCHDB_USERNAME=myusername \
     -e COUCHDB_PASSWORD=mypassword \
     -e COUCHDB_DBNAME=mydb \
@@ -86,7 +90,9 @@ $ docker run -d \
 
 #### Persistent data
 
-The CouchDB server is configured to store data in the `/usr/local/var/lib/couchdb/` directory inside the container. You can map this path to a volume on the host so the data becomes independent of the running container:
+The CouchDB server is configured to store data in the `/usr/local/var/lib/couchdb/` directory
+ inside the container. You can map this path to a volume on the host so the data becomes
+ independent of the running container:
 
 ```
 $ mkdir -p /tmp/couchdb

--- a/scripts/couchdb_gateway.sh
+++ b/scripts/couchdb_gateway.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+startCouchDbInBackground() {
+  /usr/local/bin/couchdb -b
+}
+
+stopCouchDb() {
+  /usr/local/bin/couchdb -d
+}
+
+isCouchDbRunnning() {
+  numericRegEx="^[0-9]+$"
+  if [ -n $1 ] && [[ $1 =~ $numericRegEx ]]; then
+    port=$1
+  else
+    port=$PORT
+  fi
+  nc -z $IP_ADDRESS $port
+  return $?
+}
+
+waitForCouchDb() {
+  while ! isCouchDbRunnning $1; do
+    sleep 1;
+  done
+}
+
+createCouchDbUser() {
+  curl -X PUT http://$IP_ADDRESS:$PORT/_config/admins/$USER -d '"'${PASS}'"'
+}
+
+createCouchDbDatabase() {
+  curl -X PUT http://$USER:$PASS@$IP_ADDRESS:$PORT/$DB
+}
+
+createCouchDbDatabaseWithoutCredentials() {
+  curl -X PUT http://$IP_ADDRESS:$PORT/$DB
+}
+
+setGeneratedPassword() {
+  PASS=$(pwgen -s -1 16)
+}

--- a/scripts/initialise_couchdb
+++ b/scripts/initialise_couchdb
@@ -7,46 +7,7 @@ DB=${COUCHDB_DBNAME:-}
 IP_ADDRESS=127.0.0.1
 PORT=5984
 
-startCouchDbInBackground() {
-  /usr/local/bin/couchdb -b
-}
-
-stopCouchDb() {
-  /usr/local/bin/couchdb -d
-}
-
-isCouchDbRunnning() {
-  numericRegEx="^[0-9]+$"
-  if [ -n $1 ] && [[ $1 =~ $numericRegEx ]]; then
-    port=$1
-  else
-    port=$PORT
-  fi
-  nc -z $IP_ADDRESS $port
-  return $?
-}
-
-waitForCouchDb() {
-  while ! isCouchDbRunnning $1; do
-    sleep 1;
-  done
-}
-
-createCouchDbUser() {
-  curl -X PUT http://$IP_ADDRESS:$PORT/_config/admins/$USER -d '"'${PASS}'"'
-}
-
-createCouchDbDatabase() {
-  curl -X PUT http://$USER:$PASS@$IP_ADDRESS:$PORT/$DB
-}
-
-createCouchDbDatabaseWithoutCredentials() {
-  curl -X PUT http://$IP_ADDRESS:$PORT/$DB
-}
-
-setGeneratedPassword() {
-  PASS=$(pwgen -s -1 16)
-}
+source ./couchdb_gateway.sh
 
 startCouchDbInBackground
 

--- a/scripts/initialise_couchdb
+++ b/scripts/initialise_couchdb
@@ -1,31 +1,81 @@
 #!/usr/bin/env bash
 
-USER=${COUCHDB_USERNAME:-couchdb}
-PASS=${COUCHDB_PASSWORD:-$(pwgen -s -1 16)}
+USER=${COUCHDB_USERNAME:-}
+PASS=${COUCHDB_PASSWORD:-}
 DB=${COUCHDB_DBNAME:-}
 
-# Start CouchDB service
-/usr/local/bin/couchdb -b
+IP_ADDRESS=127.0.0.1
+PORT=5984
 
-while ! nc -vz localhost 5984; do sleep 1; done
+startCouchDbInBackground() {
+  /usr/local/bin/couchdb -b
+}
 
-echo "Creating user: \"$USER\"..."
-curl -X PUT http://127.0.0.1:5984/_config/admins/$USER -d '"'${PASS}'"'
+stopCouchDb() {
+  /usr/local/bin/couchdb -d
+}
 
-if [ ! -z "$DB" ]; then
-    echo "Creating database: \"$DB\"..."
-    curl -X PUT http://$USER:$PASS@127.0.0.1:5984/$DB
+isCouchDbRunnning() {
+  numericRegEx="^[0-9]+$"
+  if [ -n $1 ] && [[ $1 =~ $numericRegEx ]]; then
+    port=$1
+  else
+    port=$PORT
+  fi
+  nc -z $IP_ADDRESS $port
+  return $?
+}
+
+waitForCouchDb() {
+  while ! isCouchDbRunnning $1; do
+    sleep 1;
+  done
+}
+
+createCouchDbUser() {
+  curl -X PUT http://$IP_ADDRESS:$PORT/_config/admins/$USER -d '"'${PASS}'"'
+}
+
+createCouchDbDatabase() {
+  curl -X PUT http://$USER:$PASS@$IP_ADDRESS:$PORT/$DB
+}
+
+createCouchDbDatabaseWithoutCredentials() {
+  curl -X PUT http://$IP_ADDRESS:$PORT/$DB
+}
+
+setGeneratedPassword() {
+  PASS=$(pwgen -s -1 16)
+}
+
+startCouchDbInBackground
+
+waitForCouchDb
+
+if [ -n "$USER" ]; then
+  if [ -z "$PASS" ]; then
+    setGeneratedPassword
+  fi
+  echo "Creating user: \"$USER\"..."
+  createCouchDbUser
 fi
 
-# Stop CouchDB service
-/usr/local/bin/couchdb -d
-
-echo "========================================================"
-echo "CouchDB User: \"$USER\""
-echo "CouchDB Password: \"$PASS\""
-if [ ! -z "$DB" ]; then
-    echo "CouchDB Database: \"$DB\""
+if [ -n "$DB" ]; then
+  echo "Creating database: \"$DB\"..."
+  if [ -n "$USER" ]; then
+    createCouchDbDatabase
+  else
+    createCouchDbDatabaseWithoutCredentials
+  fi
 fi
-echo "========================================================"
 
-rm -f /var/lib/couchdb/couchdb-not-inited
+stopCouchDb
+
+if [ -n "$USER" ]; then
+  echo "========================================================"
+  echo "CouchDB User: \"$USER\""
+  echo "CouchDB Password: \"$PASS\""
+  echo "========================================================"
+fi
+
+exit 0

--- a/scripts/start_couchdb
+++ b/scripts/start_couchdb
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-if [[ -e /var/lib/couchdb/couchdb-not-inited ]]; then
+couchDbInitIndicator=/var/lib/couchdb/couchdb-not-inited
+
+if [[ -e $couchDbInitIndicator ]]; then
   echo "Initialising CouchDB..."
   initialise_couchdb
+  rm -f $couchDbInitIndicator
 fi
 
 echo "Starting CouchDB..."


### PR DESCRIPTION
The container no longer creates administrator credentials. It is also
able to create a database even if the administrator user name and
password haven't been specified.

The rationale for this change is it should be possible to use this
image as a basis for a custom one where you might want to create
the administrator user and/or database and potentially populate it
with data or sync data from another instance - all these things
done as an anonymous user (CouchDB gives you full access until an
administrator account has been set up).

The scripts initialising the database have been heavily re-factored
replacing the procedural approach with a bunch of functions with
self-explanatory names.
