### PR TITLE
Make image smaller by merging commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN \
   apt-get install -y --force-yes --no-install-recommends \
     build-essential \
     curl \
+    # klaemo: Erlang downloaded from Erlang Solutions
     erlang-dev \
     erlang-nox \
     libcurl4-openssl-dev \
@@ -20,6 +21,7 @@ RUN \
     netcat \
     pwgen
 
+# Use COPY instead
 ADD scripts /usr/local/bin
 
 RUN \
@@ -32,9 +34,12 @@ RUN \
 RUN \
   DEBIAN_FRONTEND=noninteractive && \
   cd /usr/src && \
+  # klaemo: also download .asc and KEYS and verify the package via `gpg`
   curl -s -o apache-couchdb.tar.gz http://mirror.ox.ac.uk/sites/rsync.apache.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz && \
+  # klaemo: --strip-components=1
   tar -xzf apache-couchdb.tar.gz && \
   cd /usr/src/apache-couchdb-$COUCHDB_VERSION && \
+  # klaemo: --with-js-lib=/usr/lib --with-js-include=/usr/include/mozjs \
   ./configure && \
   make --quiet && \
   make install
@@ -52,11 +57,13 @@ RUN \
 RUN \
   mkdir /var/lib/couchdb && \
   touch /var/lib/couchdb/couchdb-not-inited && \
+  # klaemo: DRY chown below
   chown -R couchdb:couchdb /var/lib/couchdb && \
   chown -R couchdb:couchdb /usr/local/etc/couchdb && \
   chown -R couchdb:couchdb /usr/local/var/lib/couchdb && \
   chown -R couchdb:couchdb /usr/local/var/log/couchdb && \
   chown -R couchdb:couchdb /usr/local/var/run/couchdb && \
+  # klaemo: DRY chmod below
   chmod -R 0770 /usr/local/etc/couchdb && \
   chmod -R 0770 /usr/local/var/lib/couchdb && \
   chmod -R 0770 /usr/local/var/log/couchdb && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,17 +57,18 @@ RUN \
 RUN \
   mkdir /var/lib/couchdb && \
   touch /var/lib/couchdb/couchdb-not-inited && \
-  # klaemo: DRY chown below
-  chown -R couchdb:couchdb /var/lib/couchdb && \
-  chown -R couchdb:couchdb /usr/local/etc/couchdb && \
-  chown -R couchdb:couchdb /usr/local/var/lib/couchdb && \
-  chown -R couchdb:couchdb /usr/local/var/log/couchdb && \
-  chown -R couchdb:couchdb /usr/local/var/run/couchdb && \
+  chown -R couchdb:couchdb \
+    /var/lib/couchdb \
+    /usr/local/etc/couchdb \
+    /usr/local/var/lib/couchdb \
+    /usr/local/var/log/couchdb \
+    /usr/local/var/run/couchdb && \
   # klaemo: DRY chmod below
-  chmod -R 0770 /usr/local/etc/couchdb && \
-  chmod -R 0770 /usr/local/var/lib/couchdb && \
-  chmod -R 0770 /usr/local/var/log/couchdb && \
-  chmod -R 0770 /usr/local/var/run/couchdb
+  chmod -R 0770 \
+    /usr/local/etc/couchdb \
+    /usr/local/var/lib/couchdb \
+    /usr/local/var/log/couchdb \
+    /usr/local/var/run/couchdb
 
 RUN \
   apt-get purge -y \


### PR DESCRIPTION
It seems like putting package installation and removal commands
in one `RUN` call has a dramatic impact on the size of the
resulting image (we are now at 227MB, down from 418MB!).
- This change required moving other things around hence the user
  creation code placed at the top,
- "DRY" some `chmod` and `chown` calls,
- Swap `ADD` with `COPY` as it's more suitable for a simple copy
  operation,
- Fix a bug where `useradd` would not create the home directory
  (`-m` flag),
- Change home and working directory to `/var/lib/couchdb`,
- Shuffle a few commands around.

Changes "borrowed" from [klaemo/docker-couchdb](https://github.com/klaemo/docker-couchdb):
- Install Erlang directly from Erlang Solutions,
- Pass flags to CouchDB's `configure` script.
